### PR TITLE
feat: invite features, respondInvites, questions, sort event by userId

### DIFF
--- a/apps/api/prisma/migrations/20250417154820_question_response/migration.sql
+++ b/apps/api/prisma/migrations/20250417154820_question_response/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "EventQuestion" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "question" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "required" BOOLEAN NOT NULL,
+    "options" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EventQuestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "QuestionResponse" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "answer" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QuestionResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QuestionResponse_questionId_userId_key" ON "QuestionResponse"("questionId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "EventQuestion" ADD CONSTRAINT "EventQuestion_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("eid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuestionResponse" ADD CONSTRAINT "QuestionResponse_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "EventQuestion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuestionResponse" ADD CONSTRAINT "QuestionResponse_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20250419124455_invite_revamp_remove_leaderboard_pref/migration.sql
+++ b/apps/api/prisma/migrations/20250419124455_invite_revamp_remove_leaderboard_pref/migration.sql
@@ -1,0 +1,163 @@
+/*
+  Warnings:
+
+  - You are about to drop the `AttendeeInvitation` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `EventQuestion` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `InvitationLetter` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Leaderboard` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `OrganizerInvitation` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Preference` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `QuestionResponse` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Questions` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Receive` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "InviteRole" AS ENUM ('ATTENDEE', 'ORGANIZER');
+
+-- CreateEnum
+CREATE TYPE "QuestionType" AS ENUM ('SHORT_ANSWER', 'MULTIPLE_CHOICE', 'CHECKBOX');
+
+-- DropForeignKey
+ALTER TABLE "AttendeeInvitation" DROP CONSTRAINT "AttendeeInvitation_eid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "AttendeeInvitation" DROP CONSTRAINT "AttendeeInvitation_letter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "AttendeeInvitation" DROP CONSTRAINT "AttendeeInvitation_uid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "EventQuestion" DROP CONSTRAINT "EventQuestion_eventId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Leaderboard" DROP CONSTRAINT "Leaderboard_eid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Leaderboard" DROP CONSTRAINT "Leaderboard_uid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OrganizerInvitation" DROP CONSTRAINT "OrganizerInvitation_eid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OrganizerInvitation" DROP CONSTRAINT "OrganizerInvitation_uid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Preference" DROP CONSTRAINT "Preference_letter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "QuestionResponse" DROP CONSTRAINT "QuestionResponse_questionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "QuestionResponse" DROP CONSTRAINT "QuestionResponse_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Questions" DROP CONSTRAINT "Questions_letter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Receive" DROP CONSTRAINT "Receive_letter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Receive" DROP CONSTRAINT "Receive_uid_fkey";
+
+-- DropTable
+DROP TABLE "AttendeeInvitation";
+
+-- DropTable
+DROP TABLE "EventQuestion";
+
+-- DropTable
+DROP TABLE "InvitationLetter";
+
+-- DropTable
+DROP TABLE "Leaderboard";
+
+-- DropTable
+DROP TABLE "OrganizerInvitation";
+
+-- DropTable
+DROP TABLE "Preference";
+
+-- DropTable
+DROP TABLE "QuestionResponse";
+
+-- DropTable
+DROP TABLE "Questions";
+
+-- DropTable
+DROP TABLE "Receive";
+
+-- CreateTable
+CREATE TABLE "Invite" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "InviteRole" NOT NULL,
+    "accept" BOOLEAN,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Invite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Question" (
+    "id" TEXT NOT NULL,
+    "inviteId" TEXT NOT NULL,
+    "question" TEXT NOT NULL,
+    "type" "QuestionType" NOT NULL,
+    "required" BOOLEAN NOT NULL DEFAULT false,
+    "options" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Question_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Response" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "answer" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Response_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Invite_eventId_idx" ON "Invite"("eventId");
+
+-- CreateIndex
+CREATE INDEX "Invite_userId_idx" ON "Invite"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invite_eventId_userId_role_key" ON "Invite"("eventId", "userId", "role");
+
+-- CreateIndex
+CREATE INDEX "Question_inviteId_idx" ON "Question"("inviteId");
+
+-- CreateIndex
+CREATE INDEX "Response_questionId_idx" ON "Response"("questionId");
+
+-- CreateIndex
+CREATE INDEX "Response_userId_idx" ON "Response"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Response_questionId_userId_key" ON "Response"("questionId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Invite" ADD CONSTRAINT "Invite_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("eid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invite" ADD CONSTRAINT "Invite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("uid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Question" ADD CONSTRAINT "Question_inviteId_fkey" FOREIGN KEY ("inviteId") REFERENCES "Invite"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Response" ADD CONSTRAINT "Response_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "Question"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Response" ADD CONSTRAINT "Response_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20250419125339_fix_after_previous/migration.sql
+++ b/apps/api/prisma/migrations/20250419125339_fix_after_previous/migration.sql
@@ -1,0 +1,96 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Question` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Response` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Question" DROP CONSTRAINT "Question_inviteId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Response" DROP CONSTRAINT "Response_questionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Response" DROP CONSTRAINT "Response_userId_fkey";
+
+-- DropTable
+DROP TABLE "Question";
+
+-- DropTable
+DROP TABLE "Response";
+
+-- CreateTable
+CREATE TABLE "EventQuestion" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "question" TEXT NOT NULL,
+    "type" "QuestionType" NOT NULL,
+    "required" BOOLEAN NOT NULL DEFAULT false,
+    "options" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EventQuestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "QuestionResponse" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "answer" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QuestionResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Leaderboard" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "uid" TEXT NOT NULL,
+    "eid" TEXT NOT NULL,
+    "score" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Leaderboard_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EventQuestion_eventId_idx" ON "EventQuestion"("eventId");
+
+-- CreateIndex
+CREATE INDEX "QuestionResponse_questionId_idx" ON "QuestionResponse"("questionId");
+
+-- CreateIndex
+CREATE INDEX "QuestionResponse_userId_idx" ON "QuestionResponse"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QuestionResponse_questionId_userId_key" ON "QuestionResponse"("questionId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Leaderboard_uid_idx" ON "Leaderboard"("uid");
+
+-- CreateIndex
+CREATE INDEX "Leaderboard_eid_idx" ON "Leaderboard"("eid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Leaderboard_uid_eid_key" ON "Leaderboard"("uid", "eid");
+
+-- AddForeignKey
+ALTER TABLE "EventQuestion" ADD CONSTRAINT "EventQuestion_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("eid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuestionResponse" ADD CONSTRAINT "QuestionResponse_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "EventQuestion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuestionResponse" ADD CONSTRAINT "QuestionResponse_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("uid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Leaderboard" ADD CONSTRAINT "Leaderboard_uid_fkey" FOREIGN KEY ("uid") REFERENCES "User"("uid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Leaderboard" ADD CONSTRAINT "Leaderboard_eid_fkey" FOREIGN KEY ("eid") REFERENCES "Event"("eid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -9,52 +9,112 @@ datasource db {
 }
 
 model User {
-  uid                  String                @id @default(cuid())
-  phone                String
-  email                String                @unique
-  dob                  DateTime
-  pref_name            String
-  first_name           String
-  last_name            String
-  payment_method       String?
-  subscription_plan    String
-  eventsHosted         Event[]
-  histories            History[]
-  attendees            Attendee[]
-  attendings           Attending[]
-  organizers           Organizer[]
-  creates              Create[]
-  mediaTaken           Media[]
-  receives             Receive[]
-  leaderboards         Leaderboard[]
-  attendeeInvitations  AttendeeInvitation[]
-  organizerInvitations OrganizerInvitation[]
+  uid               String             @id @default(cuid())
+  phone             String
+  email             String             @unique
+  dob               DateTime
+  pref_name         String
+  first_name        String
+  last_name         String
+  payment_method    String?
+  subscription_plan String
+  eventsHosted      Event[]
+  histories         History[]
+  attendees         Attendee[]
+  attendings        Attending[]
+  organizers        Organizer[]
+  creates           Create[]
+  mediaTaken        Media[]
+  invites           Invite[]
+  responses         QuestionResponse[]
+  leaderboard       Leaderboard[]
 }
 
 model Event {
-  eid                  String                @id @default(cuid())
-  name                 String
-  date                 DateTime
-  time                 DateTime
-  picture              String[]
-  location             String
-  description          String?
-  invite_list          Int
-  memory               String?
-  host                 String
-  host_uid             String
-  status               String
-  hostUser             User                  @relation(fields: [host_uid], references: [uid], onDelete: Cascade)
-  histories            History[]
-  attendees            Attendee[]
-  attendings           Attending[]
-  organizers           Organizer[]
-  creates              Create[]
-  media                Media[]
-  updates              Update[]
-  attendeeInvitations  AttendeeInvitation[]
-  organizerInvitations OrganizerInvitation[]
-  Leaderboard          Leaderboard[]
+  eid         String          @id @default(cuid())
+  name        String
+  date        DateTime
+  time        DateTime
+  picture     String[]
+  location    String
+  description String?
+  invite_list Int
+  memory      String?
+  host        String
+  host_uid    String
+  status      String
+  hostUser    User            @relation(fields: [host_uid], references: [uid], onDelete: Cascade)
+  histories   History[]
+  attendees   Attendee[]
+  attendings  Attending[]
+  organizers  Organizer[]
+  creates     Create[]
+  media       Media[]
+  updates     Update[]
+  invites     Invite[]
+  questions   EventQuestion[]
+
+  Leaderboard Leaderboard[]
+}
+
+model Invite {
+  id        String     @id @default(cuid())
+  eventId   String
+  userId    String
+  role      InviteRole
+  accept    Boolean?
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  event Event @relation(fields: [eventId], references: [eid], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [uid], onDelete: Cascade)
+
+  @@unique([eventId, userId, role])
+  @@index([eventId])
+  @@index([userId])
+}
+
+enum InviteRole {
+  ATTENDEE
+  ORGANIZER
+}
+
+model EventQuestion {
+  id        String       @id @default(cuid())
+  eventId   String
+  question  String
+  type      QuestionType
+  required  Boolean      @default(false)
+  options   String[]
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+
+  event     Event              @relation(fields: [eventId], references: [eid], onDelete: Cascade)
+  responses QuestionResponse[]
+
+  @@index([eventId])
+}
+
+enum QuestionType {
+  SHORT_ANSWER
+  MULTIPLE_CHOICE
+  CHECKBOX
+}
+
+model QuestionResponse {
+  id         String   @id @default(cuid())
+  questionId String
+  userId     String
+  answer     String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  question EventQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  user     User          @relation(fields: [userId], references: [uid], onDelete: Cascade)
+
+  @@unique([questionId, userId])
+  @@index([questionId])
+  @@index([userId])
 }
 
 model History {
@@ -119,80 +179,19 @@ model Update {
   event           Event    @relation(fields: [eid], references: [eid], onDelete: Cascade)
 }
 
-model InvitationLetter {
-  letter_id           String               @id @default(cuid())
-  description         String?
-  receives            Receive[]
-  attendeeInvitations AttendeeInvitation[]
-  preferences         Preference[]
-  questions           Questions[]
-}
-
-model Receive {
-  uid              String
-  letter_id        String
-  user             User             @relation(fields: [uid], references: [uid], onDelete: Cascade)
-  invitationLetter InvitationLetter @relation(fields: [letter_id], references: [letter_id], onDelete: Cascade)
-
-  @@id([uid, letter_id])
-}
-
-model AttendeeInvitation {
-  id         String   @id @default(cuid())
-  eid        String
-  uid        String
-  letter_id  String?
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
-  accept     Boolean?
-
-  event            Event              @relation(fields: [eid], references: [eid], onDelete: Cascade)
-  user             User               @relation(fields: [uid], references: [uid], onDelete: Cascade)
-  invitationLetter InvitationLetter? @relation(fields: [letter_id], references: [letter_id], onDelete: Cascade)
-
-  @@unique([eid, uid])
-}
-
-model OrganizerInvitation {
-  id         String   @id @default(cuid())
-  eid        String
-  uid        String
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
-  accept     Boolean?
-
-  event Event @relation(fields: [eid], references: [eid], onDelete: Cascade)
-  user  User  @relation(fields: [uid], references: [uid], onDelete: Cascade)
-
-  @@unique([eid, uid])
-}
-
-model Preference {
-  preference_id    String
-  letter_id        String
-  notes            String?
-  seat             String?
-  food             String?
-  invitationLetter InvitationLetter @relation(fields: [letter_id], references: [letter_id], onDelete: Cascade)
-
-  @@id([preference_id, letter_id])
-}
-
-model Questions {
-  question_id      String           @default(cuid())
-  letter_id        String
-  question         String?
-  answer           String?
-  invitationLetter InvitationLetter @relation(fields: [letter_id], references: [letter_id], onDelete: Cascade)
-
-  @@id([question_id, letter_id])
-}
-
 model Leaderboard {
-  name  String @id
-  uid   String
-  eid   String
-  score Int?
-  user  User   @relation(fields: [uid], references: [uid], onDelete: Cascade)
-  event Event  @relation(fields: [eid], references: [eid], onDelete: Cascade)
+  id        String   @id @default(cuid())
+  name      String
+  uid       String
+  eid       String
+  score     Int?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user  User  @relation(fields: [uid], references: [uid], onDelete: Cascade)
+  event Event @relation(fields: [eid], references: [eid], onDelete: Cascade)
+
+  @@unique([uid, eid])
+  @@index([uid])
+  @@index([eid])
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -138,55 +138,55 @@ async function main() {
     });
   }
 
-  // Create InvitationLetters
-  const invitationLetters = await prisma.invitationLetter.createMany({
-    data: Array.from({ length: 5 }, () => ({
-      description: faker.lorem.paragraph(),
-    })),
-  });
+  // // Create InvitationLetters
+  // const invitationLetters = await prisma.invitationLetter.createMany({
+  //   data: Array.from({ length: 5 }, () => ({
+  //     description: faker.lorem.paragraph(),
+  //   })),
+  // });
 
-  // Fetch created invitation letters
-  const invitationLetterList = await prisma.invitationLetter.findMany();
+  // // Fetch created invitation letters
+  // const invitationLetterList = await prisma.invitationLetter.findMany();
 
-  // Create Receives
-  for (const letter of invitationLetterList) {
-    const user = faker.helpers.arrayElement(userList) as (typeof userList)[0];
-    try {
-      await prisma.receive.create({
-        data: {
-          uid: user.uid,
-          letter_id: letter.letter_id,
-        },
-      });
-    } catch (error) {
-      console.log(`Receive already exists for user ${user.uid} and letter ${letter.letter_id}`);
-    }
-  }
+  // // Create Receives
+  // for (const letter of invitationLetterList) {
+  //   const user = faker.helpers.arrayElement(userList) as (typeof userList)[0];
+  //   try {
+  //     await prisma.receive.create({
+  //       data: {
+  //         uid: user.uid,
+  //         letter_id: letter.letter_id,
+  //       },
+  //     });
+  //   } catch (error) {
+  //     console.log(`Receive already exists for user ${user.uid} and letter ${letter.letter_id}`);
+  //   }
+  // }
 
-  // Create Preferences
-  for (const letter of invitationLetterList) {
-    await prisma.preference.create({
-      data: {
-        preference_id: faker.string.alphanumeric(7),
-        letter_id: letter.letter_id,
-        notes: faker.lorem.sentence(),
-        seat: `Table ${faker.number.int({ min: 1, max: 20 })}`,
-        food: faker.helpers.arrayElement(['Vegetarian', 'Vegan', 'No restrictions', 'Gluten-free']),
-      },
-    });
-  }
+  // // Create Preferences
+  // for (const letter of invitationLetterList) {
+  //   await prisma.preference.create({
+  //     data: {
+  //       preference_id: faker.string.alphanumeric(7),
+  //       letter_id: letter.letter_id,
+  //       notes: faker.lorem.sentence(),
+  //       seat: `Table ${faker.number.int({ min: 1, max: 20 })}`,
+  //       food: faker.helpers.arrayElement(['Vegetarian', 'Vegan', 'No restrictions', 'Gluten-free']),
+  //     },
+  //   });
+  // }
 
-  // Create Questions
-  for (const letter of invitationLetterList) {
-    await prisma.questions.create({
-      data: {
-        question_id: faker.string.uuid(),
-        letter_id: letter.letter_id,
-        question: faker.lorem.sentence() + '?',
-        answer: faker.datatype.boolean() ? faker.lorem.sentence() : null,
-      },
-    });
-  }
+  // // Create Questions
+  // for (const letter of invitationLetterList) {
+  //   await prisma.questions.create({
+  //     data: {
+  //       question_id: faker.string.uuid(),
+  //       letter_id: letter.letter_id,
+  //       question: faker.lorem.sentence() + '?',
+  //       answer: faker.datatype.boolean() ? faker.lorem.sentence() : null,
+  //     },
+  //   });
+  // }
 
   // Create Leaderboards
   for (const event of eventList) {
@@ -233,58 +233,58 @@ async function main() {
 
     const eligibleAttendees = attendees.filter((a) => !existingOrganizerIds.includes(a.uid));
 
-    // Better approach: Process only the first 2 eligible attendees using slice
-    // This ensures we never try to access an element beyond the array length
-    const attendeesToInvite = eligibleAttendees.slice(0, 2);
+    //   // Better approach: Process only the first 2 eligible attendees using slice
+    //   // This ensures we never try to access an element beyond the array length
+    //   const attendeesToInvite = eligibleAttendees.slice(0, 2);
 
-    for (const attendeeToInvite of attendeesToInvite) {
-      try {
-        await prisma.organizerInvitation.create({
-          data: {
-            eid: event.eid,
-            uid: attendeeToInvite.uid,
-            accept: null, // pending
-          },
-        });
-        console.log(`Created organizer invitation for user ${attendeeToInvite.uid} to event ${event.eid}`);
-      } catch (error) {
-        console.log(`Error creating organizer invitation for user ${attendeeToInvite.uid} to event ${event.eid}`);
-      }
-    }
-  }
+    //   for (const attendeeToInvite of attendeesToInvite) {
+    //     try {
+    //       await prisma.organizerInvitation.create({
+    //         data: {
+    //           eid: event.eid,
+    //           uid: attendeeToInvite.uid,
+    //           accept: null, // pending
+    //         },
+    //       });
+    //       console.log(`Created organizer invitation for user ${attendeeToInvite.uid} to event ${event.eid}`);
+    //     } catch (error) {
+    //       console.log(`Error creating organizer invitation for user ${attendeeToInvite.uid} to event ${event.eid}`);
+    //     }
+    //   }
+    // }
 
-  // Create Attendee Invitations
-  console.log('Creating attendee invitations...');
-  for (const event of eventList) {
-    // Get an invitation letter to connect (optional)
-    const invitationLetter = await prisma.invitationLetter.findFirst();
+    // // Create Attendee Invitations
+    // console.log('Creating attendee invitations...');
+    // for (const event of eventList) {
+    //   // Get an invitation letter to connect (optional)
+    //   const invitationLetter = await prisma.invitationLetter.findFirst();
 
-    const existingAttendees = await prisma.attendee.findMany({
-      where: { eid: event.eid },
-      select: { uid: true },
-    });
+    //   const existingAttendees = await prisma.attendee.findMany({
+    //     where: { eid: event.eid },
+    //     select: { uid: true },
+    //   });
 
-    const existingAttendeeIds = existingAttendees.map((a) => a.uid);
-    const eligibleUsers = userList.filter((user) => !existingAttendeeIds.includes(user.uid));
+    //   const existingAttendeeIds = existingAttendees.map((a) => a.uid);
+    //   const eligibleUsers = userList.filter((user) => !existingAttendeeIds.includes(user.uid));
 
-    const usersToInvite = eligibleUsers.slice(0, 2);
+    //   const usersToInvite = eligibleUsers.slice(0, 2);
 
-    for (const userToInvite of usersToInvite) {
-      try {
-        // Create attendee invitation with optional letter reference
-        await prisma.attendeeInvitation.create({
-          data: {
-            eid: event.eid,
-            uid: userToInvite.uid,
-            accept: null,
-            letter_id: invitationLetter?.letter_id, // Optional connection
-          },
-        });
-        console.log(`Created attendee invitation for user ${userToInvite.uid} to event ${event.eid}`);
-      } catch (error) {
-        console.log(`Error creating attendee invitation for user ${userToInvite.uid} to event ${event.eid}:`, error);
-      }
-    }
+    //   for (const userToInvite of usersToInvite) {
+    //     try {
+    //       // Create attendee invitation with optional letter reference
+    //       await prisma.attendeeInvitation.create({
+    //         data: {
+    //           eid: event.eid,
+    //           uid: userToInvite.uid,
+    //           accept: null,
+    //           letter_id: invitationLetter?.letter_id, // Optional connection
+    //         },
+    //       });
+    //       console.log(`Created attendee invitation for user ${userToInvite.uid} to event ${event.eid}`);
+    //     } catch (error) {
+    //       console.log(`Error creating attendee invitation for user ${userToInvite.uid} to event ${event.eid}:`, error);
+    //     }
+    //   }
   }
 
   console.log('Seeding completed.');

--- a/apps/api/src/modules/attendee/attendee.adapter.ts
+++ b/apps/api/src/modules/attendee/attendee.adapter.ts
@@ -1,4 +1,4 @@
-import { EventEntity, LeaderboardEntity, InviteEntity } from './types';
+import { EventEntity, InviteEntity, LeaderboardEntity } from './types';
 
 export const AttendeeAdapter = {
   toEventAttendeeInfo: (event: EventEntity) => {
@@ -22,7 +22,7 @@ export const AttendeeAdapter = {
   },
   toLeaderboardEntry: (entry: LeaderboardEntity) => {
     return {
-      name: entry.name,
+      entryId: entry.id,
       uid: entry.uid,
       eid: entry.eid,
       score: entry.score,

--- a/apps/api/src/modules/attendee/attendee.adapter.ts
+++ b/apps/api/src/modules/attendee/attendee.adapter.ts
@@ -1,4 +1,4 @@
-import { EventEntity, LeaderboardEntity } from './types';
+import { EventEntity, LeaderboardEntity, InviteEntity } from './types';
 
 export const AttendeeAdapter = {
   toEventAttendeeInfo: (event: EventEntity) => {
@@ -26,6 +26,15 @@ export const AttendeeAdapter = {
       uid: entry.uid,
       eid: entry.eid,
       score: entry.score,
+    };
+  },
+  toEventInviteInfo: (invite: InviteEntity) => {
+    return {
+      inviteId: invite.id,
+      eventId: invite.eventId,
+      userId: invite.userId,
+      role: invite.role,
+      accept: invite.accept,
     };
   },
 };

--- a/apps/api/src/modules/attendee/attendee.controller.ts
+++ b/apps/api/src/modules/attendee/attendee.controller.ts
@@ -1,6 +1,7 @@
 import { contract } from '@sommhai/api-contract';
 import { RouterImplementation } from '@ts-rest/express/src/lib/types';
 
+import { InternalServerErrorException } from '../../common/exception/http';
 import { AttendeeAdapter } from './attendee.adapter';
 import { AttendeeService } from './attendee.service';
 
@@ -27,5 +28,9 @@ export const AttendeeController: RouterImplementation<typeof contract.attendee> 
       status: 200,
       body: leaderboard.map((entry) => AttendeeAdapter.toLeaderboardEntry(entry)),
     };
+  },
+  respondAttendeeInvite: async ({ params: { inviteId }, body: { accept } }) => {
+    const response = await AttendeeService.respondToInvite({ inviteId, accept });
+    throw new InternalServerErrorException('Not implemented');
   },
 };

--- a/apps/api/src/modules/attendee/attendee.controller.ts
+++ b/apps/api/src/modules/attendee/attendee.controller.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unused-imports/no-unused-vars */
 import { contract } from '@sommhai/api-contract';
 import { RouterImplementation } from '@ts-rest/express/src/lib/types';
 
@@ -30,6 +31,7 @@ export const AttendeeController: RouterImplementation<typeof contract.attendee> 
     };
   },
   respondAttendeeInvite: async ({ params: { inviteId }, body: { accept } }) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const response = await AttendeeService.respondToInvite({ inviteId, accept });
     throw new InternalServerErrorException('Not implemented');
   },

--- a/apps/api/src/modules/attendee/attendee.service.ts
+++ b/apps/api/src/modules/attendee/attendee.service.ts
@@ -1,8 +1,9 @@
 import { InternalServerErrorException, NotFoundException } from '../../common/exception/http';
 import prisma from '../../common/libs/prisma';
-import { GetEventLeaderboardOptions, GetEventOptions, GetManyEventsOptions } from './types';
+import { GetEventLeaderboardOptions, GetEventOptions, GetManyEventsOptions, RespondToEventInviteOptions } from './types';
 
 export const AttendeeService = {
+  getAtdEvents: async ({ search, date, take, skip, status }: GetManyEventsOptions) => {
   getAtdEvents: async ({ search, date, take, skip, status }: GetManyEventsOptions) => {
     const events = await prisma.event.findMany({
       take,
@@ -16,6 +17,10 @@ export const AttendeeService = {
           },
           description: {
             contains: search,
+            mode: 'insensitive',
+          },
+          status: {
+            contains: status,
             mode: 'insensitive',
           },
           status: {
@@ -78,5 +83,17 @@ export const AttendeeService = {
       console.error('Error getting event leaderboard:', error);
       throw new InternalServerErrorException(error, 'Failed to get event leaderboard');
     }
+  },
+  respondToInvite: async ({ inviteId, accept }: RespondToEventInviteOptions) => {
+    const response = await prisma.invite.update({
+      where: {
+        id: inviteId,
+      },
+      data: {
+        accept,
+      },
+    });
+
+    return response;
   },
 };

--- a/apps/api/src/modules/attendee/attendee.service.ts
+++ b/apps/api/src/modules/attendee/attendee.service.ts
@@ -1,9 +1,13 @@
 import { InternalServerErrorException, NotFoundException } from '../../common/exception/http';
 import prisma from '../../common/libs/prisma';
-import { GetEventLeaderboardOptions, GetEventOptions, GetManyEventsOptions, RespondToEventInviteOptions } from './types';
+import {
+  GetEventLeaderboardOptions,
+  GetEventOptions,
+  GetManyEventsOptions,
+  RespondToEventInviteOptions,
+} from './types';
 
 export const AttendeeService = {
-  getAtdEvents: async ({ search, date, take, skip, status }: GetManyEventsOptions) => {
   getAtdEvents: async ({ search, date, take, skip, status }: GetManyEventsOptions) => {
     const events = await prisma.event.findMany({
       take,
@@ -17,10 +21,6 @@ export const AttendeeService = {
           },
           description: {
             contains: search,
-            mode: 'insensitive',
-          },
-          status: {
-            contains: status,
             mode: 'insensitive',
           },
           status: {

--- a/apps/api/src/modules/attendee/types.ts
+++ b/apps/api/src/modules/attendee/types.ts
@@ -25,3 +25,15 @@ export interface GetEventLeaderboardOptions {
 }
 
 export type LeaderboardEntity = Prisma.LeaderboardGetPayload<object>;
+
+export interface RespondToEventInviteOptions {
+  inviteId: string;
+  accept: boolean;
+}
+
+export type InviteEntity = Prisma.InviteGetPayload<{
+  include: {
+    event: true;
+    user: true;
+  };
+}>;

--- a/apps/api/src/modules/organizer/organizer.adapter.ts
+++ b/apps/api/src/modules/organizer/organizer.adapter.ts
@@ -1,4 +1,6 @@
-import { EventEntity, LeaderboardEntity } from './types';
+import { EventQuestion } from '@prisma/client';
+
+import { EventEntity, InviteEntity, LeaderboardEntity } from './types';
 
 export const OrganizerAdapter = {
   toEventOrganizerInfo: (event: EventEntity) => {
@@ -26,6 +28,27 @@ export const OrganizerAdapter = {
       uid: entry.uid,
       eid: entry.eid,
       score: entry.score,
+    };
+  },
+  toEventInviteInfo: (invite: InviteEntity) => {
+    return {
+      inviteId: invite.id,
+      eventId: invite.eventId,
+      userId: invite.userId,
+      role: invite.role,
+      accept: invite.accept,
+    };
+  },
+  toEventQuestionInfo: (question: EventQuestion) => {
+    return {
+      qid: question.id,
+      eventId: question.eventId,
+      question: question.question,
+      type: question.type,
+      required: question.required,
+      options: question.options,
+      createdAt: question.createdAt,
+      updatedAt: question.updatedAt,
     };
   },
 };

--- a/apps/api/src/modules/organizer/organizer.adapter.ts
+++ b/apps/api/src/modules/organizer/organizer.adapter.ts
@@ -24,7 +24,7 @@ export const OrganizerAdapter = {
   },
   toLeaderboardEntry: (entry: LeaderboardEntity) => {
     return {
-      name: entry.name,
+      entryId: entry.id,
       uid: entry.uid,
       eid: entry.eid,
       score: entry.score,

--- a/apps/api/src/modules/organizer/organizer.controller.ts
+++ b/apps/api/src/modules/organizer/organizer.controller.ts
@@ -230,10 +230,9 @@ export const OrganizerController: RouterImplementation<typeof contract.organizer
     };
   },
 
-  createLeaderboard: async ({ params: { eventId }, body: { name, uid, score } }) => {
+  createLeaderboard: async ({ params: { eventId }, body: { uid, score } }) => {
     const newEntry = await OrganizerService.createLeaderboard({
       eventId,
-      name,
       uid,
       score,
     });
@@ -244,12 +243,12 @@ export const OrganizerController: RouterImplementation<typeof contract.organizer
     };
   },
 
-  updateLeaderboard: async ({ params: { eventId, name }, body: { name: newName, score } }) => {
+  updateLeaderboard: async ({ params: { eventId, entryId }, body: { uid, score } }) => {
     const updatedEntry = await OrganizerService.updateLeaderboard({
       eventId,
-      name,
+      entryId,
       updates: {
-        name: newName,
+        uid,
         score,
       },
     });
@@ -260,12 +259,12 @@ export const OrganizerController: RouterImplementation<typeof contract.organizer
     };
   },
 
-  deleteLeaderboardEntry: async ({ params: { eventId, name } }) => {
-    await OrganizerService.deleteLeaderboardEntry({ eventId, name });
+  deleteLeaderboardEntry: async ({ params: { eventId, entryId } }) => {
+    const deletedEntry = await OrganizerService.deleteLeaderboardEntry({ eventId, entryId });
 
     return {
       status: 204,
-      body: null,
+      body: OrganizerAdapter.toLeaderboardEntry(deletedEntry),
     };
   },
 };

--- a/apps/api/src/modules/organizer/organizer.controller.ts
+++ b/apps/api/src/modules/organizer/organizer.controller.ts
@@ -1,3 +1,4 @@
+import { InviteRole, QuestionType } from '@prisma/client';
 import { contract } from '@sommhai/api-contract';
 import { RouterImplementation } from '@ts-rest/express/src/lib/types';
 
@@ -13,8 +14,8 @@ export const OrganizerController: RouterImplementation<typeof contract.organizer
       body: OrganizerAdapter.toEventOrganizerInfo(event),
     };
   },
-  getEvents: async ({ query: { search, date, take, skip, status } }) => {
-    const events = await OrganizerService.getEvents({ search, date, take, skip, status });
+  getEvents: async ({ query: { search, date, take, skip, status, userId } }) => {
+    const events = await OrganizerService.getEvents({ search, date, take, skip, status, userId });
 
     return {
       status: 200,
@@ -49,7 +50,7 @@ export const OrganizerController: RouterImplementation<typeof contract.organizer
     params: { eventId },
     body: { name, date, description, invite_list, memory, location, time, picture },
   }) => {
-    await OrganizerService.updateEventDetails({
+    await OrganizerService.updateEvent({
       eventId,
       event: {
         name,
@@ -70,28 +71,154 @@ export const OrganizerController: RouterImplementation<typeof contract.organizer
       body: OrganizerAdapter.toEventOrganizerInfo(event),
     };
   },
+
   inviteAttendees: async ({ params: { eventId }, body: { uids } }) => {
-    const attendeeInvitation = await OrganizerService.inviteAttendees({ eventId, uids });
+    const result = await OrganizerService.createInvites({
+      eventId,
+      userIds: uids,
+      role: InviteRole.ATTENDEE,
+    });
 
     return {
       status: 201,
-      body: attendeeInvitation,
+      body: result,
     };
   },
 
   inviteOrganizers: async ({ params: { eventId }, body: { uids } }) => {
-    const organizerInvitation = await OrganizerService.inviteOrganizers({ eventId, uids });
+    const result = await OrganizerService.createInvites({
+      eventId,
+      userIds: uids,
+      role: InviteRole.ORGANIZER,
+    });
 
     return {
       status: 201,
-      body: organizerInvitation,
+      body: result,
     };
   },
-  respondOrganizerInvite: async ({ params: { invitationId }, body: { accept } }) => {
-    const response = await OrganizerService.respondOrganizerInvite({ invitationId, accept });
+  getEventInvites: async ({ params: { eventId }, query: { role, accept, take, skip } }) => {
+    let inviteRole: InviteRole | undefined;
+    if (role) {
+      inviteRole = role === 'ATTENDEE' ? InviteRole.ATTENDEE : InviteRole.ORGANIZER;
+    }
+
+    const result = await OrganizerService.getEventInvites({
+      eventId,
+      role: inviteRole,
+      accept: accept,
+      take: take ? Number(take) : undefined,
+      skip: skip ? Number(skip) : undefined,
+    });
+
     return {
       status: 200,
-      body: response,
+      body: result.map((invite) => OrganizerAdapter.toEventInviteInfo(invite)),
+    };
+  },
+  getEventInvite: async ({ params: { eventId, inviteId } }) => {
+    const result = await OrganizerService.getEventInvite({ eventId, inviteId });
+
+    return {
+      status: 200,
+      body: OrganizerAdapter.toEventInviteInfo(result),
+    };
+  },
+  deleteEventInvite: async ({ params: { eventId }, body: { inviteIds } }) => {
+    const results = await OrganizerService.deleteEventInvite({
+      eventId,
+      inviteIds,
+    });
+
+    return {
+      status: 200,
+      body: results.map((result) => OrganizerAdapter.toEventInviteInfo(result)),
+    };
+  },
+  respondOrganizerInvite: async ({ params: { inviteId }, body: { accept } }) => {
+    const result = await OrganizerService.respondToInvite({
+      inviteId,
+      accept: accept ?? false,
+    });
+
+    return {
+      status: 200,
+      body: result,
+    };
+  },
+  getEventQuestions: async ({ params: { eventId } }) => {
+    const questions = await OrganizerService.getEventQuestions({ eventId });
+    return {
+      status: 200,
+      body: questions.map((questions) => OrganizerAdapter.toEventQuestionInfo(questions)),
+    };
+  },
+  getEventQuestion: async ({ params: { eventId, questionId } }) => {
+    const question = await OrganizerService.getEventQuestion({ eventId, questionId });
+
+    return {
+      status: 200,
+      body: OrganizerAdapter.toEventQuestionInfo(question),
+    };
+  },
+  createEventQuestions: async ({ params: { eventId }, body: { questions } }) => {
+    const createdQuestions = await OrganizerService.createEventQuestions({
+      eventId,
+      questions: questions.map((q) => ({
+        question: q.question,
+        type: q.type as QuestionType,
+        required: q.required,
+        options: q.options,
+      })),
+    });
+
+    return {
+      status: 201,
+      body: createdQuestions.map((q) => OrganizerAdapter.toEventQuestionInfo(q)),
+    };
+  },
+  updateEventQuestion: async ({ params: { eventId, questionId }, body: { question, type, required, options } }) => {
+    const updatedQuestion = await OrganizerService.updateEventQuestion({
+      eventId,
+      questionId,
+      question: question ?? '',
+      type: type as QuestionType,
+      required: required ?? false,
+      options,
+    });
+
+    return {
+      status: 200,
+      body: OrganizerAdapter.toEventQuestionInfo(updatedQuestion),
+    };
+  },
+  deleteEventQuestion: async ({ params: { eventId, questionId } }) => {
+    const deletedQuestion = await OrganizerService.deleteEventQuestion({
+      eventId,
+      questionId,
+    });
+
+    return {
+      status: 200,
+      body: OrganizerAdapter.toEventQuestionInfo(deletedQuestion),
+    };
+  },
+  deleteEventQuestions: async ({ params: { eventId }, body: { questionIds } }) => {
+    const deletedQuestions = await OrganizerService.deleteEventQuestions({
+      eventId,
+      questionIds,
+    });
+    return {
+      status: 200,
+      body: deletedQuestions.map((q) => OrganizerAdapter.toEventQuestionInfo(q)),
+    };
+  },
+  deleteAllEventQuestions: async ({ params: { eventId } }: { params: { eventId: string } }) => {
+    const deletedQuestions = await OrganizerService.deleteAllEventQuestions({ eventId });
+
+    return {
+      status: 200,
+      body: deletedQuestions.map((q) => OrganizerAdapter.toEventQuestionInfo(q)),
     };
   },
   getLeaderboard: async ({ params: { eventId } }) => {

--- a/apps/api/src/modules/organizer/organizer.service.ts
+++ b/apps/api/src/modules/organizer/organizer.service.ts
@@ -1,47 +1,89 @@
-import { Prisma } from '@prisma/client';
+import { InviteRole, Prisma, QuestionType } from '@prisma/client';
 
 import { ConflictException, InternalServerErrorException, NotFoundException } from '../../common/exception/http';
 import prisma from '../../common/libs/prisma';
 import {
-  CreateAttendeeInviteOptions,
+  CreateEventInviteOptions,
   createLeaderboardOptions,
-  CreateOrganizerInviteOptions,
+  CreateManyEventQuestionOptions,
+  deleteAllEventQuestionOptions,
+  DeleteEventInviteOptions,
+  DeleteManyEventQuestionOptions,
+  GetEventInviteOptions,
   DeleteLeaderboardEntryOptions,
   GetEventLeaderboardOptions,
   GetEventOptions,
+  GetEventQuestionOptions,
+  GetManyEventInvitesOptions,
+  GetManyEventQuestionOptions,
   GetManyEventsOptions,
-  RespondOrganizerInviteOptions,
+  RespondToEventInviteOptions,
   updateLeaderboardOptions,
+  UpdateEventQuestionOptions,
 } from './types';
 
 export const OrganizerService = {
-  getEvents: async ({ search, date, take, skip, status }: GetManyEventsOptions) => {
+  getEvents: async ({ search, date, take, skip, status, userId }: GetManyEventsOptions) => {
     const events = await prisma.event.findMany({
       take,
       skip,
       where: {
         date,
-        AND: {
-          name: {
-            contains: search,
-            mode: 'insensitive',
+        AND: [
+          {
+            OR: [
+              {
+                name: {
+                  contains: search,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                description: {
+                  contains: search,
+                  mode: 'insensitive',
+                },
+              },
+            ],
           },
-          description: {
-            contains: search,
-            mode: 'insensitive',
-          },
-          status: {
-            contains: status,
-            mode: 'insensitive',
-          },
-        },
+          status
+            ? {
+                status: {
+                  contains: status,
+                  mode: 'insensitive',
+                },
+              }
+            : {},
+          userId
+            ? {
+                OR: [
+                  {
+                    host_uid: userId,
+                  },
+                  {
+                    organizers: {
+                      some: {
+                        uid: userId,
+                      },
+                    },
+                  },
+                  {
+                    attendees: {
+                      some: {
+                        uid: userId,
+                      },
+                    },
+                  },
+                ],
+              }
+            : {},
+        ],
       },
       include: {
         attendees: true,
         attendings: true,
         organizers: true,
       },
-
       orderBy: {
         date: 'desc',
       },
@@ -106,7 +148,7 @@ export const OrganizerService = {
       throw new InternalServerErrorException('Failed to create event');
     }
   },
-  updateEventDetails: async ({ eventId, event }: { eventId: string; event: Prisma.EventUncheckedUpdateInput }) => {
+  updateEvent: async ({ eventId, event }: { eventId: string; event: Prisma.EventUncheckedUpdateInput }) => {
     try {
       return await prisma.event.update({
         where: {
@@ -122,7 +164,7 @@ export const OrganizerService = {
       throw new InternalServerErrorException('Failed to update event details');
     }
   },
-  inviteAttendees: async ({ eventId, uids }: CreateAttendeeInviteOptions) => {
+  createInvites: async ({ eventId, userIds, role }: CreateEventInviteOptions) => {
     try {
       const event = await prisma.event.findUnique({
         where: { eid: eventId },
@@ -132,81 +174,102 @@ export const OrganizerService = {
         throw new NotFoundException('Event not found');
       }
 
-      const createdInvitations = await Promise.all(
-        uids.map(async (uid) => {
+      const invites = await Promise.all(
+        userIds.map(async (userId) => {
           try {
             const user = await prisma.user.findUnique({
-              where: { uid },
+              where: { uid: userId },
             });
 
             if (!user) {
               return {
                 success: false,
-                uid,
+                uid: userId,
                 error: 'User not found',
               };
             }
 
-            const existingAttendee = await prisma.attendee.findUnique({
-              where: {
-                uid_eid: {
-                  uid,
-                  eid: eventId,
+            if (role === InviteRole.ATTENDEE) {
+              const existingAttendee = await prisma.attendee.findUnique({
+                where: {
+                  uid_eid: {
+                    uid: userId,
+                    eid: eventId,
+                  },
                 },
-              },
-            });
+              });
 
-            if (existingAttendee) {
-              return {
-                success: false,
-                uid,
-                error: 'User is already an attendee',
-              };
+              if (existingAttendee) {
+                return {
+                  success: false,
+                  uid: userId,
+                  error: 'User is already an attendee',
+                };
+              }
+            } else if (role === InviteRole.ORGANIZER) {
+              const existingOrganizer = await prisma.organizer.findUnique({
+                where: {
+                  uid_eid: {
+                    uid: userId,
+                    eid: eventId,
+                  },
+                },
+              });
+
+              if (existingOrganizer) {
+                return {
+                  success: false,
+                  uid: userId,
+                  error: 'User is already an organizer',
+                };
+              }
             }
 
-            const existingInvitation = await prisma.attendeeInvitation.findUnique({
+            const existingInvite = await prisma.invite.findUnique({
               where: {
-                eid_uid: {
-                  eid: eventId,
-                  uid,
+                eventId_userId_role: {
+                  eventId,
+                  userId,
+                  role,
                 },
               },
             });
 
-            if (existingInvitation) {
-              await prisma.attendeeInvitation.update({
-                where: { id: existingInvitation.id },
+            if (existingInvite) {
+              const updatedInvite = await prisma.invite.update({
+                where: { id: existingInvite.id },
                 data: {
                   accept: null,
-                  updated_at: new Date(),
+                  updatedAt: new Date(),
                 },
               });
 
               return {
                 success: true,
-                uid,
-                invitationId: existingInvitation.id,
+                uid: userId,
+                inviteId: updatedInvite.id,
               };
             }
 
-            const invitation = await prisma.attendeeInvitation.create({
+            const newInvite = await prisma.invite.create({
               data: {
-                eid: eventId,
-                uid,
+                eventId,
+                userId,
+                role,
                 accept: null,
               },
             });
 
             return {
               success: true,
-              uid,
-              invitationId: invitation.id,
+              uid: userId,
+              inviteId: newInvite.id,
             };
           } catch (error) {
-            console.error(`Error inviting user ${uid}:`, error);
+            console.error(`Error creating invite for user ${userId}:`, error);
             return {
               success: false,
-              uid,
+              uid: userId,
               error: 'Failed to create invitation',
             };
           }
@@ -215,182 +278,565 @@ export const OrganizerService = {
 
       return {
         eventId,
-        invitations: createdInvitations,
+        invites,
       };
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw error;
       }
-      console.error('Error inviting attendees:', error);
-      throw new InternalServerErrorException('Failed to invite attendees');
+      console.error('Error creating invitations:', error);
+      throw new InternalServerErrorException('Failed to create invitations');
     }
   },
-  inviteOrganizers: async ({ eventId, uids }: CreateOrganizerInviteOptions) => {
+  getEventInvites: async ({ eventId, role, accept, take, skip }: GetManyEventInvitesOptions) => {
     try {
       const event = await prisma.event.findUnique({
         where: { eid: eventId },
       });
-
       if (!event) {
         throw new NotFoundException('Event not found');
       }
-
-      const createdInvitations = await Promise.all(
-        uids.map(async (uid) => {
-          try {
-            const user = await prisma.user.findUnique({
-              where: { uid },
-            });
-
-            if (!user) {
-              return {
-                success: false,
-                uid,
-                error: 'User not found',
-              };
-            }
-
-            const existingOrganizer = await prisma.organizer.findUnique({
-              where: {
-                uid_eid: {
-                  uid,
-                  eid: eventId,
-                },
-              },
-            });
-
-            if (existingOrganizer) {
-              return {
-                success: false,
-                uid,
-                error: 'User is already an organizer',
-              };
-            }
-
-            const existingInvitation = await prisma.organizerInvitation.findUnique({
-              where: {
-                eid_uid: {
-                  eid: eventId,
-                  uid,
-                },
-              },
-            });
-
-            if (existingInvitation) {
-              await prisma.organizerInvitation.update({
-                where: { id: existingInvitation.id },
-                data: {
-                  accept: null,
-                  updated_at: new Date(),
-                },
-              });
-
-              return {
-                success: true,
-                uid,
-                invitationId: existingInvitation.id,
-              };
-            }
-
-            const invitation = await prisma.organizerInvitation.create({
-              data: {
-                eid: eventId,
-                uid,
-                accept: null,
-              },
-            });
-
-            return {
-              success: true,
-              uid,
-              invitationId: invitation.id,
-            };
-          } catch (error) {
-            console.error(`Error inviting user ${uid}:`, error);
-            return {
-              success: false,
-              uid,
-              error: 'Failed to create invitation',
-            };
-          }
-        }),
-      );
-
-      return {
-        eventId,
-        invitations: createdInvitations,
-      };
+      const invites = await prisma.invite.findMany({
+        where: {
+          eventId,
+          ...(role ? { role } : {}),
+          ...(accept !== undefined ? { accept } : {}),
+        },
+        take,
+        skip,
+        include: {
+          event: true,
+          user: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      return invites;
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw error;
       }
-      console.error('Error inviting organizers:', error);
-      throw new InternalServerErrorException('Failed to invite organizers');
+      console.error('Error fetching event invitations:', error);
+      throw new InternalServerErrorException('Failed to fetch event invitations');
     }
   },
-  respondOrganizerInvite: async ({ invitationId, accept }: RespondOrganizerInviteOptions) => {
+  getEventInvite: async ({ inviteId }: GetEventInviteOptions) => {
     try {
-      const invitation = await prisma.organizerInvitation.findUnique({
-        where: { id: invitationId },
+      const invite = await prisma.invite.findUnique({
+        where: { id: inviteId },
+        include: {
+          event: true,
+          user: true,
+        },
       });
 
-      if (!invitation) {
+      if (!invite) {
         throw new NotFoundException('Invitation not found');
       }
 
-      await prisma.organizerInvitation.update({
-        where: { id: invitationId },
+      return invite;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error fetching invitation details:', error);
+      throw new InternalServerErrorException('Failed to fetch invitation details');
+    }
+  },
+  deleteEventInvite: async ({ eventId, inviteIds }: DeleteEventInviteOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException('Event not found');
+      }
+
+      const invitesToDelete = await prisma.invite.findMany({
+        where: {
+          id: { in: inviteIds },
+          eventId: eventId,
+        },
+        include: {
+          user: true,
+          event: true,
+        },
+      });
+
+      if (invitesToDelete.length !== inviteIds.length) {
+        const foundIds = invitesToDelete.map((invite) => invite.id);
+        const missingIds = inviteIds.filter((id) => !foundIds.includes(id));
+        throw new NotFoundException(`Some invitations were not found: ${missingIds.join(', ')}`);
+      }
+
+      await prisma.$transaction([
+        prisma.invite.deleteMany({
+          where: {
+            id: { in: inviteIds },
+            eventId: eventId,
+          },
+        }),
+      ]);
+
+      return invitesToDelete;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error deleting invitations in batch:', error);
+      throw new InternalServerErrorException('Failed to delete invitations');
+    }
+  },
+  respondToInvite: async ({ inviteId, accept }: RespondToEventInviteOptions) => {
+    try {
+      const invite = await prisma.invite.findUnique({
+        where: { id: inviteId },
+      });
+
+      if (!invite) {
+        throw new NotFoundException('Invitation not found');
+      }
+
+      await prisma.invite.update({
+        where: { id: inviteId },
         data: { accept },
       });
 
       if (accept) {
-        const existingOrganizer = await prisma.organizer.findUnique({
-          where: {
-            uid_eid: {
-              uid: invitation.uid,
-              eid: invitation.eid,
-            },
-          },
-        });
-
-        if (!existingOrganizer) {
-          await prisma.organizer.create({
-            data: {
-              uid: invitation.uid,
-              eid: invitation.eid,
+        if (invite.role === InviteRole.ATTENDEE) {
+          const existingAttendee = await prisma.attendee.findUnique({
+            where: {
+              uid_eid: {
+                uid: invite.userId,
+                eid: invite.eventId,
+              },
             },
           });
-        }
 
-        const existingAttendee = await prisma.attendee.findUnique({
-          where: {
-            uid_eid: {
-              uid: invitation.uid,
-              eid: invitation.eid,
-            },
-          },
-        });
-
-        if (!existingAttendee) {
-          await prisma.attendee.create({
-            data: {
-              uid: invitation.uid,
-              eid: invitation.eid,
+          if (!existingAttendee) {
+            await prisma.attendee.create({
+              data: {
+                uid: invite.userId,
+                eid: invite.eventId,
+              },
+            });
+          }
+        } else if (invite.role === InviteRole.ORGANIZER) {
+          const existingOrganizer = await prisma.organizer.findUnique({
+            where: {
+              uid_eid: {
+                uid: invite.userId,
+                eid: invite.eventId,
+              },
             },
           });
+
+          if (!existingOrganizer) {
+            await prisma.organizer.create({
+              data: {
+                uid: invite.userId,
+                eid: invite.eventId,
+              },
+            });
+
+            const existingAttendee = await prisma.attendee.findUnique({
+              where: {
+                uid_eid: {
+                  uid: invite.userId,
+                  eid: invite.eventId,
+                },
+              },
+            });
+
+            if (!existingAttendee) {
+              await prisma.attendee.create({
+                data: {
+                  uid: invite.userId,
+                  eid: invite.eventId,
+                },
+              });
+            }
+          }
         }
       }
+
       return {
-        iid: invitation.id,
-        eventId: invitation.eid,
+        iid: invite.id,
+        eventId: invite.eventId,
         accepted: accept,
       };
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw error;
       }
-      console.error('Error responding to organizer invite:', error);
-      throw new InternalServerErrorException('Failed to respond to organizer invitation');
+      console.error('Error responding to invitation:', error);
+      throw new InternalServerErrorException('Failed to respond to invitation');
+    }
+  },
+  getEventQuestions: async ({ eventId }: GetManyEventQuestionOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException('Event not found');
+      }
+
+      const questions = await prisma.eventQuestion.findMany({
+        where: { eventId },
+        orderBy: { createdAt: 'asc' },
+      });
+
+      return questions;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error fetching event questions:', error);
+      throw new InternalServerErrorException('Failed to fetch event questions');
+    }
+  },
+  getEventQuestion: async ({ eventId, questionId }: GetEventQuestionOptions) => {
+    try {
+      const question = await prisma.eventQuestion.findFirst({
+        where: {
+          id: questionId,
+          eventId,
+        },
+      });
+
+      if (!question) {
+        throw new NotFoundException('Question not found for this event');
+      }
+
+      return question;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error fetching event question:', error);
+      throw new InternalServerErrorException('Failed to fetch event question');
+    }
+  },
+  createEventQuestions: async ({ eventId, questions }: CreateManyEventQuestionOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException('Event not found');
+      }
+
+      const createdQuestions = await prisma.$transaction(
+        questions.map((q) =>
+          prisma.eventQuestion.create({
+            data: {
+              eventId,
+              question: q.question,
+              type: q.type as QuestionType,
+              required: q.required ?? false,
+              options: q.options ?? [],
+            },
+          }),
+        ),
+      );
+
+      return createdQuestions;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error creating event questions:', error);
+      throw new InternalServerErrorException('Failed to create event questions');
+    }
+  },
+  updateEventQuestion: async ({
+    eventId,
+    questionId,
+    question,
+    type,
+    required,
+    options,
+  }: UpdateEventQuestionOptions) => {
+    try {
+      const existingQuestion = await prisma.eventQuestion.findFirst({
+        where: {
+          id: questionId,
+          eventId,
+        },
+      });
+
+      if (!existingQuestion) {
+        throw new NotFoundException('Question not found for this event');
+      }
+
+      const updatedQuestion = await prisma.eventQuestion.update({
+        where: { id: questionId },
+        data: {
+          question,
+          type: type as QuestionType | undefined,
+          required,
+          options,
+        },
+      });
+
+      return updatedQuestion;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error updating event question:', error);
+      throw new InternalServerErrorException('Failed to update event question');
+    }
+  },
+  deleteEventQuestion: async ({ eventId, questionId }: GetEventQuestionOptions) => {
+    try {
+      const question = await prisma.eventQuestion.findFirst({
+        where: {
+          id: questionId,
+          eventId,
+        },
+      });
+
+      if (!question) {
+        throw new NotFoundException('Question not found for this event');
+      }
+
+      await prisma.eventQuestion.delete({
+        where: { id: questionId },
+      });
+
+      return question;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error deleting event question:', error);
+      throw new InternalServerErrorException('Failed to delete event question');
+    }
+  },
+  deleteEventQuestions: async ({ eventId, questionIds }: DeleteManyEventQuestionOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+      if (!event) {
+        throw new NotFoundException('Event not found');
+      }
+      const questionsToDelete = await prisma.eventQuestion.findMany({
+        where: {
+          id: { in: questionIds },
+          eventId,
+        },
+      });
+      if (questionsToDelete.length !== questionIds.length) {
+        const foundIds = questionsToDelete.map((question) => question.id);
+        const missingIds = questionIds.filter((id) => !foundIds.includes(id));
+        throw new NotFoundException(`Some questions were not found: ${missingIds.join(', ')}`);
+      }
+      await prisma.eventQuestion.deleteMany({
+        where: {
+          id: { in: questionIds },
+          eventId,
+        },
+      });
+      return questionsToDelete;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error deleting event questions in batch:', error);
+      throw new InternalServerErrorException('Failed to delete event questions');
+    }
+  },
+  deleteAllEventQuestions: async ({ eventId }: deleteAllEventQuestionOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException('Event not found');
+      }
+
+      const questions = await prisma.eventQuestion.findMany({
+        where: { eventId },
+      });
+
+      await prisma.eventQuestion.deleteMany({
+        where: { eventId },
+      });
+
+      return questions;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error deleting all event questions:', error);
+      throw new InternalServerErrorException('Failed to delete all event questions');
+    }
+  },
+  getEventLeaderboard: async ({ eventId }: GetEventLeaderboardOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException(`Event with ID ${eventId} not found`);
+      }
+
+      const leaderboardEntries = await prisma.leaderboard.findMany({
+        where: { eid: eventId },
+        orderBy: { score: 'desc' },
+      });
+
+      return leaderboardEntries;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error getting event leaderboard:', error);
+      throw new InternalServerErrorException(error, 'Failed to get event leaderboard');
+    }
+  },
+
+  createLeaderboard: async ({ eventId, name, uid, score = 0 }: createLeaderboardOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException(`Event with ID ${eventId} not found`);
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { uid },
+      });
+
+      if (!user) {
+        throw new NotFoundException(`User with ID ${uid} not found`);
+      }
+
+      const existingEntry = await prisma.leaderboard.findFirst({
+        where: {
+          name,
+          eid: eventId,
+        },
+      });
+
+      if (existingEntry) {
+        throw new ConflictException(`Leaderboard entry with name '${name}' already exists`);
+      }
+
+      const newEntry = await prisma.leaderboard.create({
+        data: {
+          name,
+          uid,
+          eid: eventId,
+          score,
+        },
+      });
+
+      return newEntry;
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof ConflictException) {
+        throw error;
+      }
+      console.error('Error creating leaderboard entry:', error);
+      throw new InternalServerErrorException(error, 'Failed to create leaderboard entry');
+    }
+  },
+
+  updateLeaderboard: async ({ eventId, name, updates }: updateLeaderboardOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException(`Event with ID ${eventId} not found`);
+      }
+
+      const existingEntry = await prisma.leaderboard.findFirst({
+        where: {
+          name,
+          eid: eventId,
+        },
+      });
+
+      if (!existingEntry) {
+        throw new NotFoundException(`Leaderboard entry '${name}' not found for this event`);
+      }
+
+      if (updates.name && updates.name !== name) {
+        const entryWithNewName = await prisma.leaderboard.findUnique({
+          where: { name: updates.name },
+        });
+
+        if (entryWithNewName) {
+          throw new ConflictException(`Leaderboard entry with name '${updates.name}' already exists`);
+        }
+      }
+
+      const updatedEntry = await prisma.leaderboard.update({
+        where: {
+          name,
+          eid: eventId,
+        },
+        data: updates,
+      });
+
+      return updatedEntry;
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof ConflictException) {
+        throw error;
+      }
+      console.error('Error updating leaderboard entry:', error);
+      throw new InternalServerErrorException(error, 'Failed to update leaderboard entry');
+    }
+  },
+
+  deleteLeaderboardEntry: async ({ eventId, name }: DeleteLeaderboardEntryOptions) => {
+    try {
+      const event = await prisma.event.findUnique({
+        where: { eid: eventId },
+      });
+
+      if (!event) {
+        throw new NotFoundException(`Event with ID ${eventId} not found`);
+      }
+
+      const existingEntry = await prisma.leaderboard.findFirst({
+        where: {
+          name,
+          eid: eventId,
+        },
+      });
+
+      if (!existingEntry) {
+        throw new NotFoundException(`Leaderboard entry '${name}' not found for this event`);
+      }
+
+      await prisma.leaderboard.delete({
+        where: {
+          name,
+          eid: eventId,
+        },
+      });
+
+      return null;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.error('Error deleting leaderboard entry:', error);
+      throw new InternalServerErrorException(error, 'Failed to delete leaderboard entry');
     }
   },
   getEventLeaderboard: async ({ eventId }: GetEventLeaderboardOptions) => {

--- a/apps/api/src/modules/organizer/organizer.service.ts
+++ b/apps/api/src/modules/organizer/organizer.service.ts
@@ -4,13 +4,13 @@ import { ConflictException, InternalServerErrorException, NotFoundException } fr
 import prisma from '../../common/libs/prisma';
 import {
   CreateEventInviteOptions,
-  createLeaderboardOptions,
+  CreateLeaderboardOptions,
   CreateManyEventQuestionOptions,
-  deleteAllEventQuestionOptions,
+  DeleteAllEventQuestionOptions,
   DeleteEventInviteOptions,
+  DeleteLeaderboardEntryOptions,
   DeleteManyEventQuestionOptions,
   GetEventInviteOptions,
-  DeleteLeaderboardEntryOptions,
   GetEventLeaderboardOptions,
   GetEventOptions,
   GetEventQuestionOptions,
@@ -18,8 +18,8 @@ import {
   GetManyEventQuestionOptions,
   GetManyEventsOptions,
   RespondToEventInviteOptions,
-  updateLeaderboardOptions,
   UpdateEventQuestionOptions,
+  UpdateLeaderboardOptions,
 } from './types';
 
 export const OrganizerService = {
@@ -653,7 +653,7 @@ export const OrganizerService = {
       throw new InternalServerErrorException('Failed to delete event questions');
     }
   },
-  deleteAllEventQuestions: async ({ eventId }: deleteAllEventQuestionOptions) => {
+  deleteAllEventQuestions: async ({ eventId }: DeleteAllEventQuestionOptions) => {
     try {
       const event = await prisma.event.findUnique({
         where: { eid: eventId },
@@ -705,7 +705,7 @@ export const OrganizerService = {
     }
   },
 
-  createLeaderboard: async ({ eventId, name, uid, score = 0 }: createLeaderboardOptions) => {
+  createLeaderboard: async ({ eventId, uid, score = 0 }: CreateLeaderboardOptions) => {
     try {
       const event = await prisma.event.findUnique({
         where: { eid: eventId },
@@ -725,7 +725,6 @@ export const OrganizerService = {
 
       const existingEntry = await prisma.leaderboard.findFirst({
         where: {
-          name,
           eid: eventId,
         },
       });
@@ -736,9 +735,9 @@ export const OrganizerService = {
 
       const newEntry = await prisma.leaderboard.create({
         data: {
-          name,
-          uid,
+          uid: uid,
           eid: eventId,
+          name: '',
           score,
         },
       });
@@ -753,7 +752,7 @@ export const OrganizerService = {
     }
   },
 
-  updateLeaderboard: async ({ eventId, name, updates }: updateLeaderboardOptions) => {
+  updateLeaderboard: async ({ eventId, entryId, updates }: UpdateLeaderboardOptions) => {
     try {
       const event = await prisma.event.findUnique({
         where: { eid: eventId },
@@ -765,29 +764,31 @@ export const OrganizerService = {
 
       const existingEntry = await prisma.leaderboard.findFirst({
         where: {
-          name,
+          id: entryId,
           eid: eventId,
         },
       });
 
       if (!existingEntry) {
-        throw new NotFoundException(`Leaderboard entry '${name}' not found for this event`);
+        throw new NotFoundException(`Leaderboard entry '${entryId}' not found for this event`);
       }
 
-      if (updates.name && updates.name !== name) {
+      if (updates.uid == existingEntry.uid) {
         const entryWithNewName = await prisma.leaderboard.findUnique({
-          where: { name: updates.name },
+          where: { uid_eid: { uid: existingEntry.uid, eid: eventId } },
         });
 
         if (entryWithNewName) {
-          throw new ConflictException(`Leaderboard entry with name '${updates.name}' already exists`);
+          throw new ConflictException(`Leaderboard entry with name '${updates.uid}' already exists`);
         }
       }
 
       const updatedEntry = await prisma.leaderboard.update({
         where: {
-          name,
-          eid: eventId,
+          uid_eid: {
+            uid: existingEntry.uid,
+            eid: eventId,
+          },
         },
         data: updates,
       });
@@ -802,7 +803,7 @@ export const OrganizerService = {
     }
   },
 
-  deleteLeaderboardEntry: async ({ eventId, name }: DeleteLeaderboardEntryOptions) => {
+  deleteLeaderboardEntry: async ({ eventId }: DeleteLeaderboardEntryOptions) => {
     try {
       const event = await prisma.event.findUnique({
         where: { eid: eventId },
@@ -814,182 +815,24 @@ export const OrganizerService = {
 
       const existingEntry = await prisma.leaderboard.findFirst({
         where: {
-          name,
           eid: eventId,
         },
       });
 
       if (!existingEntry) {
-        throw new NotFoundException(`Leaderboard entry '${name}' not found for this event`);
+        throw new NotFoundException(`Leaderboard entry not found for this event`);
       }
 
       await prisma.leaderboard.delete({
         where: {
-          name,
-          eid: eventId,
+          uid_eid: {
+            uid: existingEntry.uid,
+            eid: eventId,
+          },
         },
       });
 
-      return null;
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw error;
-      }
-      console.error('Error deleting leaderboard entry:', error);
-      throw new InternalServerErrorException(error, 'Failed to delete leaderboard entry');
-    }
-  },
-  getEventLeaderboard: async ({ eventId }: GetEventLeaderboardOptions) => {
-    try {
-      const event = await prisma.event.findUnique({
-        where: { eid: eventId },
-      });
-
-      if (!event) {
-        throw new NotFoundException(`Event with ID ${eventId} not found`);
-      }
-
-      const leaderboardEntries = await prisma.leaderboard.findMany({
-        where: { eid: eventId },
-        orderBy: { score: 'desc' },
-      });
-
-      return leaderboardEntries;
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw error;
-      }
-      console.error('Error getting event leaderboard:', error);
-      throw new InternalServerErrorException(error, 'Failed to get event leaderboard');
-    }
-  },
-
-  createLeaderboard: async ({ eventId, name, uid, score = 0 }: createLeaderboardOptions) => {
-    try {
-      const event = await prisma.event.findUnique({
-        where: { eid: eventId },
-      });
-
-      if (!event) {
-        throw new NotFoundException(`Event with ID ${eventId} not found`);
-      }
-
-      const user = await prisma.user.findUnique({
-        where: { uid },
-      });
-
-      if (!user) {
-        throw new NotFoundException(`User with ID ${uid} not found`);
-      }
-
-      const existingEntry = await prisma.leaderboard.findFirst({
-        where: {
-          name,
-          eid: eventId,
-        },
-      });
-
-      if (existingEntry) {
-        throw new ConflictException(`Leaderboard entry with name '${name}' already exists`);
-      }
-
-      const newEntry = await prisma.leaderboard.create({
-        data: {
-          name,
-          uid,
-          eid: eventId,
-          score,
-        },
-      });
-
-      return newEntry;
-    } catch (error) {
-      if (error instanceof NotFoundException || error instanceof ConflictException) {
-        throw error;
-      }
-      console.error('Error creating leaderboard entry:', error);
-      throw new InternalServerErrorException(error, 'Failed to create leaderboard entry');
-    }
-  },
-
-  updateLeaderboard: async ({ eventId, name, updates }: updateLeaderboardOptions) => {
-    try {
-      const event = await prisma.event.findUnique({
-        where: { eid: eventId },
-      });
-
-      if (!event) {
-        throw new NotFoundException(`Event with ID ${eventId} not found`);
-      }
-
-      const existingEntry = await prisma.leaderboard.findFirst({
-        where: {
-          name,
-          eid: eventId,
-        },
-      });
-
-      if (!existingEntry) {
-        throw new NotFoundException(`Leaderboard entry '${name}' not found for this event`);
-      }
-
-      if (updates.name && updates.name !== name) {
-        const entryWithNewName = await prisma.leaderboard.findUnique({
-          where: { name: updates.name },
-        });
-
-        if (entryWithNewName) {
-          throw new ConflictException(`Leaderboard entry with name '${updates.name}' already exists`);
-        }
-      }
-
-      const updatedEntry = await prisma.leaderboard.update({
-        where: {
-          name,
-          eid: eventId,
-        },
-        data: updates,
-      });
-
-      return updatedEntry;
-    } catch (error) {
-      if (error instanceof NotFoundException || error instanceof ConflictException) {
-        throw error;
-      }
-      console.error('Error updating leaderboard entry:', error);
-      throw new InternalServerErrorException(error, 'Failed to update leaderboard entry');
-    }
-  },
-
-  deleteLeaderboardEntry: async ({ eventId, name }: DeleteLeaderboardEntryOptions) => {
-    try {
-      const event = await prisma.event.findUnique({
-        where: { eid: eventId },
-      });
-
-      if (!event) {
-        throw new NotFoundException(`Event with ID ${eventId} not found`);
-      }
-
-      const existingEntry = await prisma.leaderboard.findFirst({
-        where: {
-          name,
-          eid: eventId,
-        },
-      });
-
-      if (!existingEntry) {
-        throw new NotFoundException(`Leaderboard entry '${name}' not found for this event`);
-      }
-
-      await prisma.leaderboard.delete({
-        where: {
-          name,
-          eid: eventId,
-        },
-      });
-
-      return null;
+      return existingEntry;
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw error;

--- a/apps/api/src/modules/organizer/types.ts
+++ b/apps/api/src/modules/organizer/types.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { InviteRole, Prisma, QuestionType } from '@prisma/client';
 
 export interface GetEventOptions {
   eventId: string;
@@ -10,6 +10,7 @@ export interface GetManyEventsOptions {
   take?: number;
   skip?: number;
   status?: string;
+  userId?: string;
 }
 
 export type EventEntity = Prisma.EventGetPayload<{
@@ -20,18 +21,31 @@ export type EventEntity = Prisma.EventGetPayload<{
   };
 }>;
 
-export interface CreateOrganizerInviteOptions {
+export interface CreateEventInviteOptions {
   eventId: string;
-  uids: string[];
+  userIds: string[];
+  role: InviteRole;
 }
 
-export interface CreateAttendeeInviteOptions {
+export interface GetEventInviteOptions {
+  inviteId: string;
   eventId: string;
-  uids: string[];
+}
+export interface GetManyEventInvitesOptions {
+  eventId: string;
+  role?: InviteRole;
+  accept?: boolean;
+  take?: number;
+  skip?: number;
 }
 
-export interface RespondOrganizerInviteOptions {
-  invitationId: string;
+export interface DeleteEventInviteOptions {
+  eventId: string;
+  inviteIds: string[];
+}
+
+export interface RespondToEventInviteOptions {
+  inviteId: string;
   accept: boolean;
 }
 
@@ -61,3 +75,54 @@ export interface DeleteLeaderboardEntryOptions {
 }
 
 export type LeaderboardEntity = Prisma.LeaderboardGetPayload<object>;
+
+export type InviteEntity = Prisma.InviteGetPayload<{
+  include: {
+    event: true;
+    user: true;
+  };
+}>;
+
+export interface GetEventQuestionOptions {
+  eventId: string;
+  questionId: string;
+}
+
+export interface GetManyEventQuestionOptions {
+  eventId: string;
+  take?: number;
+  skip?: number;
+}
+
+export interface CreateManyEventQuestionOptions {
+  eventId: string;
+  questions: Array<{
+    question: string;
+    type: QuestionType;
+    required?: boolean;
+    options?: string[];
+  }>;
+}
+
+export interface UpdateEventQuestionOptions {
+  eventId: string;
+  questionId: string;
+  question: string;
+  type: QuestionType;
+  required: boolean;
+  options?: string[];
+}
+
+export interface DeleteEventQuestionOptions {
+  eventId: string;
+  questionId: string;
+}
+
+export interface DeleteManyEventQuestionOptions {
+  eventId: string;
+  questionIds: string[];
+}
+
+export interface deleteAllEventQuestionOptions {
+  eventId: string;
+}

--- a/apps/api/src/modules/organizer/types.ts
+++ b/apps/api/src/modules/organizer/types.ts
@@ -53,25 +53,24 @@ export interface GetEventLeaderboardOptions {
   eventId: string;
 }
 
-export interface createLeaderboardOptions {
+export interface CreateLeaderboardOptions {
   eventId: string;
-  name: string;
   uid: string;
   score?: number;
 }
 
-export interface updateLeaderboardOptions {
+export interface UpdateLeaderboardOptions {
   eventId: string;
-  name: string;
+  entryId: string;
   updates: {
-    name?: string;
+    uid?: string;
     score?: number;
   };
 }
 
 export interface DeleteLeaderboardEntryOptions {
   eventId: string;
-  name: string;
+  entryId: string;
 }
 
 export type LeaderboardEntity = Prisma.LeaderboardGetPayload<object>;
@@ -123,6 +122,6 @@ export interface DeleteManyEventQuestionOptions {
   questionIds: string[];
 }
 
-export interface deleteAllEventQuestionOptions {
+export interface DeleteAllEventQuestionOptions {
   eventId: string;
 }

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -53,10 +53,9 @@ export const UserService = {
         histories: true,
         creates: true,
         mediaTaken: true,
-        receives: true,
-        leaderboards: true,
-        attendeeInvitations: true,
-        organizerInvitations: true,
+        invites: true,
+        responses: true,
+        leaderboard: true,
       },
     });
 
@@ -115,10 +114,9 @@ export const UserService = {
         histories: true,
         creates: true,
         mediaTaken: true,
-        receives: true,
-        leaderboards: true,
-        attendeeInvitations: true,
-        organizerInvitations: true,
+        invites: true,
+        responses: true,
+        leaderboard: true,
       },
       orderBy: {
         pref_name: 'asc',

--- a/packages/api-contract/src/contracts/attendee.ts
+++ b/packages/api-contract/src/contracts/attendee.ts
@@ -1,4 +1,4 @@
-import { eventAttendeeInfo } from '@sommhai/shared-type';
+import { eventAttendeeInfo, eventInvResponse } from '@sommhai/shared-type';
 import { leaderboardData } from '@sommhai/shared-type';
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -42,6 +42,21 @@ export const attendeeContract = c.router({
     }),
     responses: {
       200: leaderboardData,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  respondAttendeeInvite: {
+    method: 'PUT',
+    path: '/atd/events/:inviteId/respond',
+    pathParams: z.object({
+      inviteId: z.string(),
+    }),
+    body: z.object({
+      accept: z.boolean(),
+    }),
+    responses: {
+      200: eventInvResponse,
       404: z.object({ message: z.string() }),
       500: z.object({ message: z.string() }),
     },

--- a/packages/api-contract/src/contracts/organizer.ts
+++ b/packages/api-contract/src/contracts/organizer.ts
@@ -1,10 +1,16 @@
 import {
-  eventAttendeeInvInfo,
+  eventInviteBaseInfo,
+  eventInvResponse,
+  eventInvSend,
   eventOrganizerInfo,
+<<<<<<< HEAD
   eventOrganizerInvInfo,
   eventOrganizerInvResponse,
   leaderboardData,
   leaderboardEntry,
+=======
+  questionBaseInfo,
+>>>>>>> 41c1495 (feat: invite features, respondInvites, questions, some minor name changes, getEvents sort userId)
 } from '@sommhai/shared-type';
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -21,6 +27,7 @@ export const organizerContract = c.router({
       take: z.string().regex(/^\d+$/).transform(Number).optional(),
       skip: z.string().regex(/^\d+$/).transform(Number).optional(),
       status: z.string().optional(),
+      userId: z.string().optional(),
     }),
     responses: {
       200: z.array(eventOrganizerInfo),
@@ -83,7 +90,7 @@ export const organizerContract = c.router({
       uids: z.array(z.string()),
     }),
     responses: {
-      201: eventOrganizerInvInfo,
+      201: eventInvSend,
       404: z.object({ message: z.string() }),
       500: z.object({ message: z.string() }),
     },
@@ -98,22 +105,233 @@ export const organizerContract = c.router({
       uids: z.array(z.string()),
     }),
     responses: {
-      201: eventAttendeeInvInfo,
+      201: eventInvSend,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  getEventInvites: {
+    method: 'GET',
+    path: '/org/events/:eventId/invites',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    query: z.object({
+      role: z.enum(['ORGANIZER', 'ATTENDEE']).optional(),
+      accept: z.boolean().optional(),
+      take: z.string().regex(/^\d+$/).transform(Number).optional(),
+      skip: z.string().regex(/^\d+$/).transform(Number).optional(),
+    }),
+    responses: {
+      200: z.array(eventInviteBaseInfo),
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  getEventInvite: {
+    method: 'GET',
+    path: '/org/events/:eventId/invites/:inviteId',
+    pathParams: z.object({
+      eventId: z.string(),
+      inviteId: z.string(),
+    }),
+    responses: {
+      200: eventInviteBaseInfo,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  deleteEventInvite: {
+    method: 'DELETE',
+    path: '/org/events/:eventId/invites',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    body: z.object({
+      inviteIds: z.array(z.string()),
+    }),
+    responses: {
+      200: z.array(eventInviteBaseInfo),
       404: z.object({ message: z.string() }),
       500: z.object({ message: z.string() }),
     },
   },
   respondOrganizerInvite: {
     method: 'PUT',
-    path: '/org/events/:invitationId/respond',
+    path: '/org/events/:inviteId/respond',
     pathParams: z.object({
-      invitationId: z.string(),
+      inviteId: z.string(),
     }),
     body: z.object({
-      accept: z.boolean(),
+      accept: z.boolean().nullable(),
     }),
     responses: {
-      200: eventOrganizerInvResponse,
+      200: eventInvResponse,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  getEventQuestions: {
+    method: 'GET',
+    path: '/org/events/:eventId/questions',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    responses: {
+      200: z.array(questionBaseInfo),
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  getEventQuestion: {
+    method: 'GET',
+    path: '/org/events/:eventId/questions/:questionId',
+    pathParams: z.object({
+      eventId: z.string(),
+      questionId: z.string(),
+    }),
+    responses: {
+      200: questionBaseInfo,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  createEventQuestions: {
+    method: 'POST',
+    path: '/org/events/:eventId/questions',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    body: z.object({
+      questions: z.array(
+        z.object({
+          question: z.string(),
+          type: z.enum(['SHORT_ANSWER', 'MULTIPLE_CHOICE', 'CHECKBOX']),
+          required: z.boolean().default(false),
+          options: z.array(z.string()).optional(),
+        }),
+      ),
+    }),
+    responses: {
+      201: z.array(questionBaseInfo),
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  updateEventQuestion: {
+    method: 'PUT',
+    path: '/events/:eventId/questions/:questionId',
+    pathParams: z.object({
+      eventId: z.string(),
+      questionId: z.string(),
+    }),
+    body: z.object({
+      question: z.string().optional(),
+      type: z.enum(['SHORT_ANSWER', 'MULTIPLE_CHOICE', 'CHECKBOX']).optional(),
+      required: z.boolean().optional(),
+      options: z.array(z.string()).optional(),
+    }),
+    responses: {
+      200: questionBaseInfo,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  deleteEventQuestion: {
+    method: 'DELETE',
+    path: '/org/events/:eventId/questions/:questionId',
+    pathParams: z.object({
+      eventId: z.string(),
+      questionId: z.string(),
+    }),
+    responses: {
+      200: questionBaseInfo,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  deleteEventQuestions: {
+    method: 'DELETE',
+    path: '/org/events/:eventId/questions',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    body: z.object({
+      questionIds: z.array(z.string()),
+    }),
+    responses: {
+      200: z.array(questionBaseInfo),
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  deleteAllEventQuestions: {
+    method: 'DELETE',
+    path: '/org/events/:eventId/questions/all',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    responses: {
+      200: z.array(questionBaseInfo),
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  getLeaderboard: {
+    method: 'GET',
+    path: '/org/events/:eventId/leaderboard',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    responses: {
+      200: leaderboardData,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  createLeaderboard: {
+    method: 'POST',
+    path: '/org/events/:eventId/leaderboard',
+    pathParams: z.object({
+      eventId: z.string(),
+    }),
+    body: z.object({
+      name: z.string(),
+      uid: z.string(),
+      score: z.number().optional(),
+    }),
+    responses: {
+      201: leaderboardEntry,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  updateLeaderboard: {
+    method: 'PUT',
+    path: '/org/events/:eventId/leaderboard/:name',
+    pathParams: z.object({
+      eventId: z.string(),
+      name: z.string(),
+    }),
+    body: z.object({
+      name: z.string().optional(),
+      score: z.number().optional(),
+    }),
+    responses: {
+      200: leaderboardEntry,
+      404: z.object({ message: z.string() }),
+      500: z.object({ message: z.string() }),
+    },
+  },
+  deleteLeaderboardEntry: {
+    method: 'DELETE',
+    path: '/org/events/:eventId/leaderboard/:name',
+    pathParams: z.object({
+      eventId: z.string(),
+      name: z.string(),
+    }),
+    responses: {
+      204: z.null(),
       404: z.object({ message: z.string() }),
       500: z.object({ message: z.string() }),
     },

--- a/packages/api-contract/src/contracts/organizer.ts
+++ b/packages/api-contract/src/contracts/organizer.ts
@@ -3,14 +3,9 @@ import {
   eventInvResponse,
   eventInvSend,
   eventOrganizerInfo,
-<<<<<<< HEAD
-  eventOrganizerInvInfo,
-  eventOrganizerInvResponse,
   leaderboardData,
   leaderboardEntry,
-=======
   questionBaseInfo,
->>>>>>> 41c1495 (feat: invite features, respondInvites, questions, some minor name changes, getEvents sort userId)
 } from '@sommhai/shared-type';
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -296,7 +291,6 @@ export const organizerContract = c.router({
       eventId: z.string(),
     }),
     body: z.object({
-      name: z.string(),
       uid: z.string(),
       score: z.number().optional(),
     }),
@@ -308,13 +302,13 @@ export const organizerContract = c.router({
   },
   updateLeaderboard: {
     method: 'PUT',
-    path: '/org/events/:eventId/leaderboard/:name',
+    path: '/org/events/:eventId/leaderboard/:entryId',
     pathParams: z.object({
       eventId: z.string(),
-      name: z.string(),
+      entryId: z.string(),
     }),
     body: z.object({
-      name: z.string().optional(),
+      uid: z.string().optional(),
       score: z.number().optional(),
     }),
     responses: {
@@ -325,72 +319,13 @@ export const organizerContract = c.router({
   },
   deleteLeaderboardEntry: {
     method: 'DELETE',
-    path: '/org/events/:eventId/leaderboard/:name',
+    path: '/org/events/:eventId/leaderboard/:entryId',
     pathParams: z.object({
       eventId: z.string(),
-      name: z.string(),
+      entryId: z.string(),
     }),
     responses: {
-      204: z.null(),
-      404: z.object({ message: z.string() }),
-      500: z.object({ message: z.string() }),
-    },
-  },
-  getLeaderboard: {
-    method: 'GET',
-    path: '/org/events/:eventId/leaderboard',
-    pathParams: z.object({
-      eventId: z.string(),
-    }),
-    responses: {
-      200: leaderboardData,
-      404: z.object({ message: z.string() }),
-      500: z.object({ message: z.string() }),
-    },
-  },
-  createLeaderboard: {
-    method: 'POST',
-    path: '/org/events/:eventId/leaderboard',
-    pathParams: z.object({
-      eventId: z.string(),
-    }),
-    body: z.object({
-      name: z.string(),
-      uid: z.string(),
-      score: z.number().optional(),
-    }),
-    responses: {
-      201: leaderboardEntry,
-      404: z.object({ message: z.string() }),
-      500: z.object({ message: z.string() }),
-    },
-  },
-  updateLeaderboard: {
-    method: 'PUT',
-    path: '/org/events/:eventId/leaderboard/:name',
-    pathParams: z.object({
-      eventId: z.string(),
-      name: z.string(),
-    }),
-    body: z.object({
-      name: z.string().optional(),
-      score: z.number().optional(),
-    }),
-    responses: {
-      200: leaderboardEntry,
-      404: z.object({ message: z.string() }),
-      500: z.object({ message: z.string() }),
-    },
-  },
-  deleteLeaderboardEntry: {
-    method: 'DELETE',
-    path: '/org/events/:eventId/leaderboard/:name',
-    pathParams: z.object({
-      eventId: z.string(),
-      name: z.string(),
-    }),
-    responses: {
-      204: z.null(),
+      204: leaderboardEntry,
       404: z.object({ message: z.string() }),
       500: z.object({ message: z.string() }),
     },

--- a/packages/shared-type/src/libs/event.ts
+++ b/packages/shared-type/src/libs/event.ts
@@ -21,13 +21,21 @@ export const eventBaseInfo = z.object({
   status: z.string(),
 });
 
-export const eventInvInfo = z.object({
+export const eventInviteBaseInfo = z.object({
+  inviteId: z.string(),
   eventId: z.string(),
-  invitations: z.array(
+  userId: z.string(),
+  role: z.enum(['ORGANIZER', 'ATTENDEE']),
+  accept: z.boolean().optional().nullable(),
+});
+
+export const eventInvSend = z.object({
+  eventId: z.string(),
+  invites: z.array(
     z.object({
       success: z.boolean(),
       uid: z.string(),
-      invitationId: z.string().optional(),
+      inviteId: z.string().optional(),
       error: z.string().optional(),
     }),
   ),
@@ -36,7 +44,27 @@ export const eventInvInfo = z.object({
 export const eventInvResponse = z.object({
   iid: z.string(),
   eventId: z.string(),
-  accepted: z.boolean(),
+  accepted: z.boolean().nullable(),
+});
+
+export const questionBaseInfo = z.object({
+  qid: z.string(),
+  eventId: z.string(),
+  question: z.string(),
+  type: z.enum(['SHORT_ANSWER', 'MULTIPLE_CHOICE', 'CHECKBOX']),
+  required: z.boolean(),
+  options: z.array(z.string()).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const userResponseBaseInfo = z.object({
+  id: z.string(),
+  questionId: z.string(),
+  userId: z.string(),
+  answer: z.string().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
 });
 
 export const leaderboardEntry = z.object({
@@ -50,9 +78,3 @@ export const leaderboardData = z.array(leaderboardEntry);
 
 export const eventOrganizerInfo = eventBaseInfo;
 export const eventAttendeeInfo = eventBaseInfo;
-
-export const eventOrganizerInvInfo = eventInvInfo;
-export const eventAttendeeInvInfo = eventInvInfo;
-
-export const eventOrganizerInvResponse = eventInvResponse;
-export const eventAttendeeInvResponse = eventInvResponse;

--- a/packages/shared-type/src/libs/event.ts
+++ b/packages/shared-type/src/libs/event.ts
@@ -68,7 +68,7 @@ export const userResponseBaseInfo = z.object({
 });
 
 export const leaderboardEntry = z.object({
-  name: z.string(),
+  entryId: z.string(),
   uid: z.string(),
   eid: z.string(),
   score: z.number().nullable(),


### PR DESCRIPTION
[…nges, getEvents sort userId](feat: invite features, respondInvites, questions, sort event by userId)

## What I did

- Invites: Create,Update,Delete
- Respond to Invites
- Questions: Create, Update, Delete, DeleteAll
- GetEvents to sort both status and userId

## GitHub issue

- N/A

## Screenshot

- N/A

## Note / Concern

- Minor changes to names to be consistent such as invitationId -> inviteId
- Seed not fixed
- Old invitation has been removed and replaced with Invites in schema.
- Leaderboard is for placeholder currently.